### PR TITLE
based on 1.14.0, support indentation in <style> tag

### DIFF
--- a/abc.vue
+++ b/abc.vue
@@ -1,0 +1,13 @@
+<style scoped         
+lang="scss">    
+$a:88;
+
+
+                  @charset 'utf-8';
+
+        .abc{color:#ccc}
+
+
+                
+                </style>
+

--- a/src/language-vue/embed.js
+++ b/src/language-vue/embed.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { concat, hardline } = require("../doc").builders;
+const { concat, hardline, indent } = require("../doc").builders;
 
 function embed(path, print, textToDoc, options) {
   const node = path.getValue();
@@ -35,12 +35,50 @@ function embed(path, print, textToDoc, options) {
     return null;
   }
 
-  return concat([
-    options.originalText.slice(node.start, node.contentStart),
-    hardline,
-    textToDoc(options.originalText.slice(node.contentStart, node.contentEnd), {
+  // build AST from source text without tags
+  // 对文本内容构建 ast 树（刨除tag，如 `<style` / `</style>`）
+  let textNodes = textToDoc(
+    options.originalText.slice(
+      node.contentStart,
+      node.contentEnd
+    ),
+    {
       parser
-    }),
+    }
+  );
+
+  // remove the last "hardline" before the ending `</style>` tag,
+  // without doing so that empty "hardline" will also get indented and generate
+  // two empty spaces(depends on you indentation) before the `</style>` tag
+  // 去掉文本尾部换行，否则缩进的时候会把换行也缩进，多出两个空格
+  //
+  // @see issue comment https://github.com/prettier/prettier/issues/3888#issuecomment-386339629
+  textNodes.parts.pop();
+  // a small optimization to reduce nesting, no harm to remove this, should be
+  // 精简嵌套层级
+  textNodes.parts = textNodes.parts[0].parts;
+
+  return concat([
+    // the `<style lang="blabla">` or `<script>`
+    options.originalText.slice(node.start, node.contentStart),
+
+    // the most important part:
+    // add a base indent to the whole source text, just as the option `baseIndent`
+    // of the `script-indent` rule of the plugin `eslint-plugin-vue` does.
+    // 对文本自身内容整体进行缩进
+    //
+    // @see https://github.com/prettier/prettier/issues/3888#issuecomment-385960667
+    indent(concat([
+      hardline,
+      textNodes,
+    ])),
+
+    // adding back the "hardline" which has been deliberately removed in
+    // previous steps
+    // 手动填补最后缺失的换行，就是 `</style>`前面的那个，否则它会和文本沾在一起
+    hardline,
+
+    // the `</style>` or `</script>`
     options.originalText.slice(node.contentEnd, node.end)
   ]);
 }


### PR DESCRIPTION
Anyone wants to use this fork may replace the official prettier with the following version in your package.json

### FYI: the current fork is based on version `v1.14.0` of the official repo.

```
"prettier": "https://github.com/maogongzi/prettier/tarball/patch-style-indentaion-v0.1",
```